### PR TITLE
Don't re-render RunView through React on every frame.

### DIFF
--- a/src/view/lesson_environment.js
+++ b/src/view/lesson_environment.js
@@ -47,7 +47,6 @@ var LessonEnvironment = React.createClass({
   },
 
   _updateCode: function(code) {
-    console.log("New code: " + code);
     this.setState({sourceCode: code});
   },
 
@@ -59,7 +58,6 @@ var LessonEnvironment = React.createClass({
   },
 
   _advanceStep: function() {
-    console.log("Advancing...");
     this._startStep(Math.min(this.props.lesson.getNumberOfSteps() - 1,
                              this.state.currentStep + 1));
   },
@@ -69,10 +67,8 @@ var LessonEnvironment = React.createClass({
   },
 
   _playCode: function() {
-    console.log("Playing code.");
     var currentStep = this.props.lesson.getStep(this.state.currentStep);
     var animator = currentStep.play(this.state.sourceCode);
-    animator.start();
     this.setState({animator: animator});
   },
 

--- a/src/view/run_view.js
+++ b/src/view/run_view.js
@@ -18,9 +18,8 @@ var RunView = React.createClass({
   componentDidUpdate: function() {
     if (this.props.animator) {
       var canvas = this.refs.canvas;
-      this.props.animator.render(canvas);
-      var self = this;
-      window.requestAnimationFrame(function() { self.forceUpdate(); });
+      this.props.animator.start();
+      this.props.animator.play(canvas);
     }
   },
 });


### PR DESCRIPTION
This was likely causing high CPU usage on trivial animations, since
on every frame we were not only re-rendering the animation but also
recreating a whole React subtree for the RunView element.

In this way we only update the canvas, and neither create a new Canvas element each time nor update the DOM.