### PR TITLE
Close paths in Animator

### DIFF
--- a/src/lesson/lesson01.js
+++ b/src/lesson/lesson01.js
@@ -84,10 +84,16 @@ Lesson01ExerciseStepPlayer.prototype = {
   render: function(actions, game, animator) {
   var success = true;
   var directions = Array();
-  console.log("Action list: ", actions);
+
   for (var i = 1; i < game.n_rows; ++i) {
-    var action = actions.shift();
-    switch(action.action) {
+    var command = actions.shift();
+    var action = "WAIT";
+
+    if (command) {
+      action = command.action;
+    }
+
+    switch (action) {
       case "LEFT":
         direction = -1;
         directions.push(direction);
@@ -101,6 +107,7 @@ Lesson01ExerciseStepPlayer.prototype = {
         directions.push(direction);
         break;
     }
+
     if (!game.moveCharacter(i, direction)) {
       success = false;
       break;
@@ -127,7 +134,7 @@ Lesson01ExerciseStepPlayer.prototype = {
           return o_y_fn;
         }()));
     animator.addAnimation(new Animator.Animation(0, directions.length,
-        'o' + i, 'radius', 
+        'o' + i, 'radius',
         function() {
           var max_y = (game.n_rows - 1) * 10;
           function o_radius_fn(t, elem) {

--- a/src/util/animator.js
+++ b/src/util/animator.js
@@ -67,6 +67,7 @@ Object.assign(RectangleElement.prototype, {
     context.lineWidth = this.line_width;
     context.strokeStyle = this.stroke_color;
     context.stroke();
+    context.closePath();
   },
 });
 
@@ -94,6 +95,7 @@ Object.assign(CircleElement.prototype, {
     context.lineWidth = this.line_width;
     context.strokeStyle = this.stroke_color;
     context.stroke();
+    context.closePath();
   },
 });
 
@@ -117,6 +119,7 @@ Object.assign(SimpleGridElement.prototype, {
     var context = canvas.getContext('2d');
     var width = this.h_cells * this.cell_width;
     var height = this.v_cells * this.cell_height;
+    context.beginPath();
     for (var x = 0; x <= this.v_cells; ++x) {
       context.moveTo(this.x + this.cell_height * x, this.y);
       context.lineTo(this.x + this.cell_height * x, this.y + width);
@@ -127,6 +130,7 @@ Object.assign(SimpleGridElement.prototype, {
     }
     context.lineWidth = this.line_width;
     context.strokeStyle = context.stroke_color;
+    context.closePath();
     context.stroke();
   },
 });

--- a/src/view/lesson_environment.js
+++ b/src/view/lesson_environment.js
@@ -47,7 +47,6 @@ var LessonEnvironment = React.createClass({
   },
 
   _updateCode: function(code) {
-    console.log("New code: " + code);
     this.setState({sourceCode: code});
   },
 
@@ -59,7 +58,6 @@ var LessonEnvironment = React.createClass({
   },
 
   _advanceStep: function() {
-    console.log("Advancing...");
     this._startStep(Math.min(this.props.lesson.getNumberOfSteps() - 1,
                              this.state.currentStep + 1));
   },
@@ -69,10 +67,8 @@ var LessonEnvironment = React.createClass({
   },
 
   _playCode: function() {
-    console.log("Playing code.");
     var currentStep = this.props.lesson.getStep(this.state.currentStep);
     var animator = currentStep.play(this.state.sourceCode);
-    animator.start();
     this.setState({animator: animator});
   },
 

--- a/src/view/run_view.js
+++ b/src/view/run_view.js
@@ -18,9 +18,8 @@ var RunView = React.createClass({
   componentDidUpdate: function() {
     if (this.props.animator) {
       var canvas = this.refs.canvas;
-      this.props.animator.render(canvas);
-      var self = this;
-      window.requestAnimationFrame(function() { self.forceUpdate(); });
+      this.props.animator.start();
+      this.props.animator.play(canvas);
     }
   },
 });


### PR DESCRIPTION
The main fix is to closePath() in SimpleGridElement.render(), since
stroke() does not automatically close the path [1].

The other closePaths() are just for safety (since fill() theoretically closes them).

This is to avoid the behavior suggested in this StackOverflow question [2], but frankly it sounds unlikely to me given the tutorial on MDN.

We still more investigation about the high CPU usage.

[1] https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes

[2] http://stackoverflow.com/questions/8169663/does-canvas-redraw-itself-everytime-anything-changes#8169924