### PR TITLE
Lesson 1: fix animation when character leaves grid or is hit.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -10,7 +10,8 @@ module.exports = {
   RUN_VIEW_SQUARE_DIMENSION: 1000,
 
   Lesson01: {
-    FAILURE_MESSAGE: "Que pena! O robô não sobreviveu. Tente novamente.",
+    FAILURE_MESSAGE_HIT_BY_ASTEROID: "Que pena! O robô foi atingido! Tente novamente.",
+    FAILURE_MESSAGE_LEFT_GRID: "Oh, o robô saiu da área de controle e ficou perdido! Ajude-o novamente.",
     SUCCESS_MESSAGE: "Muito bem! Mais um robô a salvo! :)",
   },
 };


### PR DESCRIPTION
When the character was being hit, the animation would go "out of sync"
because the animation was timed so that all the asteroids would hit the
ground by the time the animation ends (won't always happen in the game
itself). This was what caused asteroids to move faster when the player
died.

This commit also handles more gracefully the case in which the character
leaves the grid, by showing a different error message.