### PR TITLE
Add ResourceLoader: only start class after loading resources.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,8 +8,17 @@ var DummyLesson = require("./lesson/dummy_lesson");
 var Lesson01 = require("./lesson/lesson01");
 var LessonEnvironment = require("./view/lesson_environment");
 
-var startLesson = function(lessonClass, domElement) {
-  ReactDOM.render(<LessonEnvironment lesson={new lessonClass()} />,
+var startLesson = function(lesson, domElement) {
+  var lessonInstance = null;
+  if (typeof(lessonClass) === 'function') {
+    lessonInstance = new lesson();
+  } else if (typeof(lesson) === 'object') {
+    lessonInstance = lesson;
+  } else {
+    console.error("Not a lesson or a lesson class: " + lesson);
+    return;
+  }
+  ReactDOM.render(<LessonEnvironment lesson={lessonInstance} />,
                   domElement);
 };
 

--- a/src/lesson/lesson.js
+++ b/src/lesson/lesson.js
@@ -2,6 +2,8 @@
  * Basic structure of a lesson.
  */
 
+var ResourceLoader = require("../util/resource_loader");
+
 /// A lesson is a sequence of lesson steps.
 function Lesson() {
   this.steps = new Array();
@@ -21,7 +23,12 @@ Lesson.prototype = {
   /// Returns the i-th step in this lesson.
   getStep: function(i) {
     return this.steps[i];
-  }
+  },
+
+  /// Returns a resource loader that loads all resources needed by the lesson.
+  getResourceLoader: function() {
+    return new ResourceLoader();
+  },
 };
 
 /// Interface for one step of a lesson.

--- a/src/lesson/lesson01.js
+++ b/src/lesson/lesson01.js
@@ -5,6 +5,7 @@
 var Lesson = require("./lesson");
 var Interpreter = require("../language/interpreter")
 var Animator = require("../util/animator");
+var ResourceLoader = require("../util/resource_loader");
 var AnimationFactories = require("../util/animator/animation_factories");
 var ElementFactories = require("../util/animator/element_factories");
 var Robolang = require("../language/robolang/robolang");
@@ -373,6 +374,13 @@ function Lesson01() {
       Constants.Lesson01.SUCCESS_MESSAGE));
 }
 
-Lesson01.prototype = Object.create(Lesson.Lesson.prototype, {});
+Lesson01.prototype = Object.create(Lesson.Lesson.prototype);
+Object.assign(Lesson01.prototype, {
+  getResourceLoader: function() {
+    var loader = new ResourceLoader();
+    loader.addImage(ElementFactories.ROBOT_IMAGE_URL);
+    return loader;
+  },
+});
 
 module.exports = Lesson01;

--- a/src/util/animator/element_factories.js
+++ b/src/util/animator/element_factories.js
@@ -4,6 +4,8 @@
 
 var animator = require("../animator");
 
+var ROBOT_IMAGE_URL = "/static/images/elements/stormtrooper.png";
+
 // Creates an AnimatedImageElement that renders to a robot.
 // It has four animations: walk_down, walk_up, walk_left and
 // walk_right.
@@ -12,7 +14,7 @@ var animator = require("../animator");
 // If none are given, the image's original size is used.
 function createRobot(id, max_width, max_height) {
   var image = new Image();
-  image.src = "/static/images/elements/stormtrooper.png";
+  image.src = ROBOT_IMAGE_URL;
   var IMAGE_WIDTH = 32;
   var IMAGE_HEIGHT = 48;
   var width = IMAGE_WIDTH;
@@ -54,4 +56,5 @@ function createRobot(id, max_width, max_height) {
 
 module.exports = {
   createRobot: createRobot,
+  ROBOT_IMAGE_URL: ROBOT_IMAGE_URL,
 };

--- a/src/util/resource_loader.js
+++ b/src/util/resource_loader.js
@@ -1,0 +1,50 @@
+/*
+ * Module that loads a list of resources to the browser cache and then calls
+ * back.
+ */
+
+function ResourceLoader() {
+  this._images = [];
+}
+
+ResourceLoader.prototype = {
+  addImage: function(url) {
+    this._images.push(url);
+  },
+  load: function(onLoad) {
+    var loaded_images = new Array();
+    loaded_images.length = this._images.length;
+    loaded_images.fill(false);
+
+    var done = function() { return loaded_images.indexOf(false) == -1; };
+
+    for (var i = 0; i < this._images.length; i++) {
+      loaded_images[i] = false;
+
+      var image = new Image();
+      var index = i;
+      var url = this._images[i];
+
+      image.onload = function() {
+        loaded_images[index] = true;
+        if (done()) {
+          onLoad();
+        }
+      };
+
+      image.onerror = function(error) {
+        console.error("Error when loading " + url + ": " + error);
+      }
+
+      image.src = url;
+    }
+
+    // If all images were already in the browser's cache, img.onload may never
+    // be called. Otherwise, it (or onerror) will be called at least once.
+    if (done()) {
+      onLoad();
+    }
+  },
+};
+
+module.exports = ResourceLoader;

--- a/tests/lessons/lesson01.js
+++ b/tests/lessons/lesson01.js
@@ -1,4 +1,6 @@
 window.onload = function() {
-  comp4kids.startLesson(comp4kids.Lesson01,
-                        document.getElementById("lesson"));
+  var lesson = new comp4kids.Lesson01();
+  lesson.getResourceLoader().load(function() {
+    comp4kids.startLesson(lesson, document.getElementById("lesson"));
+  });
 };


### PR DESCRIPTION
Fixes #19 by loading images before starting the class.

By creating a virtual element before, we force the browser to load the image to its local cache, and it will be stored locally by the second time it's loaded from within the class.