### PR TITLE
Make default grid thicker.

### DIFF
--- a/src/util/animator.js
+++ b/src/util/animator.js
@@ -115,7 +115,7 @@ var SimpleGridElement = function(id, cell_width, h_cells, cell_height, v_cells,
   this.h_cells = h_cells || 10;
   this.v_cells = v_cells || this.h_cells;
   this.stroke_color = stroke_color || 'black';
-  this.line_width = line_width || 1;
+  this.line_width = line_width || 2;
 }
 
 SimpleGridElement.prototype = Object.create(Element.prototype);


### PR DESCRIPTION
Making the grid 2 pixels thick prevents rounding problems in some resolutions. 2 pixels are always
shown, but one pixel sometimes rounds to zero.

This fixes a problem Nildo had observed. I've been able to reproduce it and test the fix.