### PR TITLE
Store resources in ResourceLoader instead of relying on browser caching

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ var Lesson01 = require("./lesson/lesson01");
 var Lesson02 = require("./lesson/lesson02");
 var Lesson03 = require("./lesson/lesson03");
 var LessonEnvironment = require("./view/lesson_environment");
+var ResourceLoader = require("./util/resource_loader")
 var Popup = require("react-popup").default;
 
 var startLesson = function(lesson, domElement) {
@@ -38,4 +39,6 @@ module.exports = {
   Lesson01: Lesson01,
   Lesson02: Lesson02,
   Lesson03: Lesson03,
+  LessonEnvironment: LessonEnvironment,
+  ResourceLoader: ResourceLoader,
 };

--- a/src/lesson/lesson.js
+++ b/src/lesson/lesson.js
@@ -25,10 +25,8 @@ Lesson.prototype = {
     return this.steps[i];
   },
 
-  /// Returns a resource loader that loads all resources needed by the lesson.
-  getResourceLoader: function() {
-    return new ResourceLoader();
-  },
+  /// Adds all resources this lesson needs to the ResourceLoader module.
+  populateResourceLoader: function() {}
 };
 
 /// Interface for one step of a lesson.

--- a/src/lesson/lesson01.js
+++ b/src/lesson/lesson01.js
@@ -710,11 +710,9 @@ function Lesson01() {
 
 Lesson01.prototype = Object.create(Lesson.Lesson.prototype);
 Object.assign(Lesson01.prototype, {
-  getResourceLoader: function() {
-    var loader = new ResourceLoader();
-    loader.addImage(ElementFactories.ROBOT_IMAGE_URL);
-    loader.addImage(ElementFactories.ASTEROIDS_IMAGE_URL);
-    return loader;
+  populateResourceLoader: function() {
+    ResourceLoader.addImage(ElementFactories.ROBOT_IMAGE_URL);
+    ResourceLoader.addImage(ElementFactories.ASTEROIDS_IMAGE_URL);
   },
 });
 

--- a/src/lesson/lesson02.js
+++ b/src/lesson/lesson02.js
@@ -972,12 +972,10 @@ function Lesson02() {
 
 Lesson02.prototype = Object.create(Lesson.Lesson.prototype);
 Object.assign(Lesson02.prototype, {
-  getResourceLoader: function() {
-    var loader = new ResourceLoader();
-    loader.addImage(ElementFactories.ROBOT_IMAGE_URL);
-    loader.addImage(ElementFactories.GOOD_BATTERY_IMAGE_URL);
-    loader.addImage(ElementFactories.BAD_BATTERY_IMAGE_URL);
-    return loader;
+  populateResourceLoader: function() {
+    ResourceLoader.addImage(ElementFactories.ROBOT_IMAGE_URL);
+    ResourceLoader.addImage(ElementFactories.GOOD_BATTERY_IMAGE_URL);
+    ResourceLoader.addImage(ElementFactories.BAD_BATTERY_IMAGE_URL);
   },
 });
 

--- a/src/lesson/lesson03.js
+++ b/src/lesson/lesson03.js
@@ -1387,10 +1387,12 @@ function Lesson03() {
 
 Lesson03.prototype = Object.create(Lesson.Lesson.prototype);
 Object.assign(Lesson03.prototype, {
-  getResourceLoader: function() {
-    var loader = new ResourceLoader();
-    loader.addImage(ElementFactories.ROBOT_IMAGE_URL);
-    return loader;
+  populateResourceLoader: function() {
+    ResourceLoader.addImage(ElementFactories.ROBOT_IMAGE_URL);
+    ResourceLoader.addImage(ElementFactories.ROBOT_HOLDING_IMAGE_URL);
+    ResourceLoader.addImage(ElementFactories.MACHINE_COMPONENT_URL);
+    ResourceLoader.addImage(ElementFactories.MACHINE_URL);
+    ResourceLoader.addImage(ElementFactories.WORKING_MACHINE_URL);
   },
 });
 

--- a/src/util/animator/element_factories.js
+++ b/src/util/animator/element_factories.js
@@ -3,6 +3,7 @@
  */
 
 var animator = require("../animator");
+var ResourceLoader = require("../resource_loader");
 
 var ROBOT_IMAGE_URL = "/static/images/elements/robot.png";
 var ROBOT_HOLDING_IMAGE_URL = "/static/images/elements/robot-with-gear.png";
@@ -38,10 +39,8 @@ var ROBOT_HOLDING_STYLE = "robot_holding";
 // original proportions, and `max_width` and `max_height`, if any are given.
 // If none are given, the image's original size is used.
 function createRobot(id, max_width, max_height) {
-  var image = new Image();
-  image.src = ROBOT_IMAGE_URL;
-  var holding_image = new Image();
-  holding_image.src = ROBOT_HOLDING_IMAGE_URL;
+  var image = ResourceLoader.get(ROBOT_IMAGE_URL);
+  var holding_image = ResourceLoader.get(ROBOT_HOLDING_IMAGE_URL, true);
   var IMAGE_WIDTH = 32;
   var IMAGE_HEIGHT = 48;
   var dimensions = calculateDimensions(max_width, max_height,
@@ -83,14 +82,14 @@ var GOOD_BATTERY_IMAGE_URL = "/static/images/elements/good-battery.png";
 var BAD_BATTERY_IMAGE_URL = "/static/images/elements/bad-battery.png";
 
 function createBattery(id, max_width, max_height, is_good) {
-  var image = new Image();
+  var image = null;
   var IMAGE_WIDTH = 32;
   var IMAGE_HEIGHT = 32;
 
   if (is_good) {
-    image.src = GOOD_BATTERY_IMAGE_URL;
+    image = ResourceLoader.get(GOOD_BATTERY_IMAGE_URL);
   } else {
-    image.src = BAD_BATTERY_IMAGE_URL;
+    image = ResourceLoader.get(BAD_BATTERY_IMAGE_URL);
   }
 
   var dimensions = calculateDimensions(max_width, max_height,
@@ -112,8 +111,7 @@ function createBattery(id, max_width, max_height, is_good) {
 }
 
 function createAsteroid(id, max_width, max_height) {
-  var image = new Image();
-  image.src = ASTEROIDS_IMAGE_URL;
+  var image = ResourceLoader.get(ASTEROIDS_IMAGE_URL);
   var IMAGE_WIDTH = 32;
   var IMAGE_HEIGHT = 32;
   var width = IMAGE_WIDTH;
@@ -162,8 +160,7 @@ function createAsteroid(id, max_width, max_height) {
 }
 
 function createMachineComponent(id, max_width, max_height) {
-  var image = new Image();
-  image.src = MACHINE_COMPONENT_URL;
+  var image = ResourceLoader.get(MACHINE_COMPONENT_URL);
   var IMAGE_WIDTH = 32;
   var IMAGE_HEIGHT = 32;
 
@@ -177,10 +174,8 @@ function createMachineComponent(id, max_width, max_height) {
 var WORKING_MACHINE_STYLE = "working_machine";
 
 function createMachine(id, max_width, max_height) {
-  var default_image = new Image();
-  default_image.src = MACHINE_URL;
-  var working_machine_image = new Image();
-  working_machine_image.src = WORKING_MACHINE_URL;
+  var default_image = ResourceLoader.get(MACHINE_URL);
+  var working_machine_image = ResourceLoader.get(WORKING_MACHINE_URL);
   var IMAGE_WIDTH = 48;
   var IMAGE_HEIGHT = 48;
   var dimensions = calculateDimensions(max_width, max_height,

--- a/src/view/button_bar.js
+++ b/src/view/button_bar.js
@@ -5,6 +5,7 @@
 
 var React = require("react");
 var Constants = require("../constants");
+var ResourceLoader = require("../util/resource_loader");
 
 var ButtonBar = React.createClass({
   _styles: {
@@ -59,5 +60,12 @@ var ButtonBar = React.createClass({
            </div>;
   },
 });
+
+ButtonBar.populateResourceLoader = function() {
+  ResourceLoader.addImage(Constants.PLAY_ICON_URL);
+  ResourceLoader.addImage(Constants.ADVANCE_ICON_URL);
+  ResourceLoader.addImage(Constants.HELP_ICON_URL);
+  ResourceLoader.addImage(Constants.RESET_ICON_URL);
+}
 
 module.exports = ButtonBar;

--- a/src/view/lesson_environment.js
+++ b/src/view/lesson_environment.js
@@ -8,6 +8,7 @@ var CodeEditor = require("./code_editor.js");
 var InstructionPane = require("./instruction_pane.js");
 var RunView = require("./run_view.js");
 var MessagePane = require("./message_pane.js");
+var ResourceLoader = require("../util/resource_loader");
 var Popup = require("react-popup").default;
 
 var LessonEnvironment = React.createClass({
@@ -165,5 +166,9 @@ var LessonEnvironment = React.createClass({
     this._reset();
   },
 });
+
+LessonEnvironment.populateResourceLoader = function() {
+  ButtonBar.populateResourceLoader();
+}
 
 module.exports = LessonEnvironment;

--- a/tests/lessons/lesson01.js
+++ b/tests/lessons/lesson01.js
@@ -1,6 +1,8 @@
 window.onload = function() {
   var lesson = new comp4kids.Lesson01();
-  lesson.getResourceLoader().load(function() {
+  lesson.populateResourceLoader();
+  comp4kids.LessonEnvironment.populateResourceLoader();
+  comp4kids.ResourceLoader.load(function() {
     comp4kids.startLesson(lesson, document.getElementById("lesson"));
   });
 };

--- a/tests/lessons/lesson02.js
+++ b/tests/lessons/lesson02.js
@@ -1,6 +1,8 @@
 window.onload = function() {
   var lesson = new comp4kids.Lesson02();
-  lesson.getResourceLoader().load(function() {
+  lesson.populateResourceLoader();
+  comp4kids.LessonEnvironment.populateResourceLoader();
+  comp4kids.ResourceLoader.load(function() {
     comp4kids.startLesson(lesson, document.getElementById("lesson"));
   });
 };

--- a/tests/lessons/lesson03.js
+++ b/tests/lessons/lesson03.js
@@ -1,6 +1,8 @@
 window.onload = function() {
   var lesson = new comp4kids.Lesson03();
-  lesson.getResourceLoader().load(function() {
+  lesson.populateResourceLoader();
+  comp4kids.LessonEnvironment.populateResourceLoader();
+  comp4kids.ResourceLoader.load(function() {
     comp4kids.startLesson(lesson, document.getElementById("lesson"));
   });
 };


### PR DESCRIPTION
Before, ResourceLoader loaded the required resources once, in the hope
that when they were loaded a second time (in ElementFactories, for
instance) they would be already cached. This is not always the case.

The fix was to load and store resources in the ResourceLoader. This
module now acts as a "singleton", holding all resources needed at the
time. Element factories directly get resources from it, assuming they
have already been loaded. Modules that require resources have a
"populateResourceLoader" function that is called before the module is
used. The lessons now start only after the resource loader module was
populated and finishes loading everything.

Fixes #30