### PR TITLE
Fix typo in lesson 03 (issue #48)

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -31,7 +31,7 @@ module.exports = {
     NO_COMPONENT_TO_GET: "O robô tentou pegar uma peça, mas não havia nenhuma...",
     NO_COMPONENT_TO_PUT: "O robô tentou colocar uma peça na máquina, mas ele não tinha peças em mãos...",
     NO_MACHINE_TO_PUT_COMPONENT_IN: "O robô tentou colocar uma peça, mas não havia uma máquina próxima.",
-    TRIED_HOLDING_TWO_COMPONENTS: "O robô tentou pegar uma peça do chão, mas ele só pode carregar uma de cada vez...",
+    CANNOT_HOLD_TWO_COMPONENTS: "O robô tentou pegar uma peça do chão, mas ele só pode carregar uma de cada vez...",
     MISSION_UNFINISHED: "O robô sobreviveu, mas não completou sua missão. Tente novamente.",
   },
 };

--- a/src/lesson/lesson03.js
+++ b/src/lesson/lesson03.js
@@ -20,7 +20,7 @@ var FailureReasons = {
   NO_COMPONENT_TO_PUT: 2,
   HIT_MACHINE: 3,
   LEFT_GRID: 4,
-  TRIED_HOLDING_TWO_COMPONENTS: 5,
+  CANNOT_HOLD_TWO_COMPONENTS: 5,
   NO_MACHINE_TO_PUT_COMPONENT_IN: 6,
   BROKE_COMPONENT: 7,
   MISSION_UNFINISHED: 8,
@@ -163,12 +163,12 @@ Lesson03Game.prototype = {
 
   /// Tries to get a component in front of the robot.
   /// If the robot is already holding a component,
-  /// returns TRIED_HOLDING_TWO_COMPONENTS.
+  /// returns CANNOT_HOLD_TWO_COMPONENTS.
   /// If there's no component to get in the attempted position, returns
   /// NO_COMPONENT_TO_GET.
   getComponent: function() {
     if (this._holding_component) {
-      return FailureReasons.TRIED_HOLDING_TWO_COMPONENTS;
+      return FailureReasons.CANNOT_HOLD_TWO_COMPONENTS;
     }
     if (this.getComponentSensorValue()) {
       this._holding_component = true;
@@ -526,8 +526,8 @@ Lesson03ExerciseStepPlayer.prototype = {
                FailureReasons.NO_MACHINE_TO_PUT_COMPONENT_IN) {
       return [Constants.Lesson03.NO_MACHINE_TO_PUT_COMPONENT_IN];
     } else if (failure_reason ===
-               FailureReasons.TRIED_HOLDING_TWO_COMPONENTS) {
-      return [Constants.Lesson03.FAILURE_MESSAGE_CANNOT_HOLD_TWO_COMPONENTS];
+               FailureReasons.CANNOT_HOLD_TWO_COMPONENTS) {
+      return [Constants.Lesson03.CANNOT_HOLD_TWO_COMPONENTS];
     } else {
       throw "Unknown failure reason " + failure_reason;
     }


### PR DESCRIPTION
Due to a typo in lesson03.js, the error message wasn't showing when the user tried to get two components at the same time. The issue was solved, I attach a screenshot.

![screenshot from 2016-09-30 02-02-54](https://cloud.githubusercontent.com/assets/8364317/19016719/e4635518-87f8-11e6-9c1a-6c630fd998c9.png)
