### PR TITLE
Add panel with reference of the commands (#47) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "flux": "2.1.1",
     "react": "15.0.2",
     "react-dom": "15.0.2",
-    "react-popup": "0.4.2"
+    "react-popup": "0.4.2",
+    "react-sidebar": "2.2.1"
   }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,6 +2,8 @@
  * Named constants.
  */
 
+var React = require("react");
+
 module.exports = {
   PLAY_ICON_URL: "/static/images/icons/play.png",
   RESET_ICON_URL: "/static/images/icons/reset.png",
@@ -33,5 +35,18 @@ module.exports = {
     NO_MACHINE_TO_PUT_COMPONENT_IN: "O robô tentou colocar uma peça, mas não havia uma máquina próxima.",
     CANNOT_HOLD_TWO_COMPONENTS: "O robô tentou pegar uma peça do chão, mas ele só pode carregar uma de cada vez...",
     MISSION_UNFINISHED: "O robô sobreviveu, mas não completou sua missão. Tente novamente.",
+  },
+  
+  References: {
+    WAIT: <p> <b>W</b>: esperar </p>,
+    MOVE_LEFT: <p> <b>L</b>: mover o robô para a esquerda </p>,
+    MOVE_RIGHT: <p> <b>R</b>: mover o robô para a direita </p>,
+    MOVE_FORWARD: <p> <b>F</b>: mover o robô para frente </p>,
+    TURN_LEFT: <p> <b>L</b>: girar o robô para a esquerda </p>,
+    TURN_RIGHT: <p> <b>R</b>: girar o robô para a direita </p>,
+    PUT_COMPONENT: <p> <b>P</b>: colocar engrenagem na máquina </p>,
+    GET_COMPONENT: <p> <b>G</b>: pegar engrenagem </p>,
+    COMPONENT_SENSOR: <p> <div> <b>eng?&#123; &#125;</b>: fazer o que está entre </div> <div> chaves apenas se houver uma </div> <div> engrenagem à frente </div> </p>,
+    MACHINE_SENSOR: <p> <div> <b>maq?&#123; &#125;</b>: fazer o que está entre  </div> <div> chaves apenas se houver uma </div> <div> máquina à frente </div> </p>,
   },
 };

--- a/src/lesson/lesson.js
+++ b/src/lesson/lesson.js
@@ -30,10 +30,11 @@ Lesson.prototype = {
 };
 
 /// Interface for one step of a lesson.
-function LessonStep(shortInstruction, instructions, player, initialCode,
-                    successMessage, codeSizeLimit) {
+function LessonStep(shortInstruction, instructions, commandReference,
+                    player, initialCode, successMessage, codeSizeLimit) {
   this.shortInstruction = shortInstruction;
   this.instructions = instructions;
+  this.commandReference = commandReference;
   this.player = player;
   this.initialCode = initialCode || "";
   this.successMessage = successMessage || null;
@@ -51,6 +52,12 @@ LessonStep.prototype = {
   /// pop-up when the step starts or when the help button is clicked.
   getInstructions: function() {
     return this.instructions;
+  },
+
+  /// Returns a reference to all the commands that the user needs to
+  /// remember to be able to solve the step.
+  getCommandReference: function() {
+      return this.commandReference;
   },
 
   /// Returns the message to be displayed when the user correctly solves this

--- a/src/lesson/lesson01.js
+++ b/src/lesson/lesson01.js
@@ -469,10 +469,15 @@ function Lesson01() {
           pode apertar o {Icons.HelpIcon}. Minha principal lição é: não entre em pânico!
         </p>
       </div>,
+      [],
       new Lesson01ExerciseStepPlayer(false, 3, 3, 1,
                                      [5, 7, 8]),
       "LW",
       Constants.Lesson01.SUCCESS_MESSAGE));
+
+  var commandsReference = [Constants.References.WAIT,
+                           Constants.References.MOVE_LEFT,
+                           Constants.References.MOVE_RIGHT];
 
   this.addStep(
     new Lesson.LessonStep(
@@ -493,6 +498,7 @@ function Lesson01() {
         Você consegue descobrir para que ela serve? Clique em {Icons.PlayIcon} para ver
         o que acontece.
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayer(false, 3, 3, 1,
                                      [3, 5, 6, 7]),
       "",
@@ -509,6 +515,7 @@ function Lesson01() {
         Eu estou tentando, mas sinto que cometi um erro
         e escrevi o programa errado. Você consegue corrigir o erro?
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayer(false, 5, 3, 1,
                                      [4, 7, 8, 9, 11, 12, 13]),
       "LWRL",
@@ -525,6 +532,7 @@ function Lesson01() {
         ajudar com os códigos. Acho que você está pronto para conduzir os
         robôs restantes pela chuva de meteoros sozinho.
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayer(false, 5, 4, 1,
                                      [5, 10, 12, 14, 16, 17, 19]),
       "",
@@ -541,6 +549,7 @@ function Lesson01() {
         ser salvo com qualquer um dos programas seguintes: LWRR, LRWR, RLWR,
         RRWL. Você acha que o mesmo é verdade para este robô?
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayer(false, 15, 3, 1,
                                      [3, 4, 6, 8, 9, 11, 12, 14, 15, 17,
                                       18, 20, 22, 23, 24, 26, 27, 28, 30, 31,
@@ -560,6 +569,7 @@ function Lesson01() {
         existe um programa que faz com que ele seja salvo sem ser atingido
         por nenhum meteoro.
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayer(false, 6, 10, 4,
                                      [11, 13, 15, 17, 22, 23, 24, 26,
                                       31, 34, 35, 37, 44, 46, 47, 48,
@@ -577,6 +587,7 @@ function Lesson01() {
         Consegue pensar em alguma maneira de salvar este
         robô com um programa de apenas um comando?
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayer(false, 5, 8, 1,
                                      [9, 17, 18, 25, 26, 27, 33, 35, 36]),
       "",
@@ -594,6 +605,7 @@ function Lesson01() {
         comandos seguintes forem somente de espera (sequência de Ws).
         Você acha que existe alguma regiao segura para o robô atual?
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayer(false, 6, 7, 3,
                                      [7, 9, 11, 13, 15, 17, 19,
                                       21, 23, 25, 27, 29, 31, 33,
@@ -610,6 +622,7 @@ function Lesson01() {
         Para o robô anterior, não existia região segura. O que acontece
         se o robô já começar em uma regiao segura?
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayer(false, 5, 5, 2,
                                      [6, 10, 13, 16, 18, 19, 21, 23]),
       "",
@@ -624,6 +637,7 @@ function Lesson01() {
         Muito bem! Essa foi fácil. Salve este outro robô. Para este novo robô, é fácil se
         confundir. Então programe com bastante atenção!
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayer(false, 10, 5, 2,
                                      [7, 11, 12, 13, 17, 22, 26, 27, 28, 29,
                                       32, 36, 38, 42, 45, 46, 47, 48]),
@@ -644,6 +658,7 @@ function Lesson01() {
          seja atingido por um meteoro. O único programa que salva os dois
          robôs, ao mesmo tempo, é WRLW (ou WRL).
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayerMulti(true, 2, [5, 5], [5, 5], [2, 2],
                                           [[6, 8, 12, 15, 18], [8, 11, 19]]),
       "WRL",
@@ -657,6 +672,7 @@ function Lesson01() {
       <p>
         Agora é sua vez. Escreva um programa que salve os dois robôs ao mesmo tempo.
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayerMulti(false, 2, [5, 5], [5, 5], [2, 2],
                                           [[6, 12, 13, 15, 19, 21, 23],
                                            [7, 11, 12, 15, 23, 24]]),
@@ -671,6 +687,7 @@ function Lesson01() {
       <p>
         Salve mais estes robôs. Estamos quase salvando todos eles! :)
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayerMulti(false, 2, [6, 6], [8, 8], [1, 4],
                                           [[9, 13, 16, 18, 19, 22, 26, 29, 32, 35,
                                             36, 41, 46], [8, 11, 18, 19, 22, 25, 28,
@@ -688,6 +705,7 @@ function Lesson01() {
         salvos com sucesso, e tudo graças a você! Espero que possamos
         trabalhar juntos novamente, e boa sorte nessa nova jornada!
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayerMulti(false, 2, [10, 10], [5, 5], [2, 2],
                                           [[7, 11, 13, 22, 26, 27, 38, 42, 46, 49],
                                            [11, 12, 13, 17, 25, 28, 32, 36, 47, 48]]),
@@ -703,6 +721,7 @@ function Lesson01() {
         E isso é tudo! Continue se divertindo salvando robôs, ou pode
         descansar por hoje! :)
       </p>,
+      commandsReference,
       new Lesson01ExerciseStepPlayer(false, 10, 10),
       "",
       Constants.Lesson01.SUCCESS_MESSAGE));

--- a/src/lesson/lesson02.js
+++ b/src/lesson/lesson02.js
@@ -385,6 +385,7 @@ function Lesson02() {
           pegarmos esta bateria.
         </p>
       </div>,
+      [Constants.References.MOVE_FORWARD],
       new Lesson02ExerciseStepPlayer(
         false, 3, 3, new Grid.Position(0, 0), Grid.Directions.RIGHT,
         [new Grid.Position(0, 2)],
@@ -408,6 +409,8 @@ function Lesson02() {
           como você já fez antes.
         </p>
       </div>,
+      [Constants.References.MOVE_FORWARD,
+       Constants.References.TURN_RIGHT],
       new Lesson02ExerciseStepPlayer(
         false, 3, 3, new Grid.Position(0, 0), Grid.Directions.UP,
         [new Grid.Position(0, 2)],
@@ -415,6 +418,10 @@ function Lesson02() {
       "",
       Constants.Lesson02.SUCCESS_MESSAGE,
       null));
+
+  var commandsReference = [Constants.References.MOVE_FORWARD,
+                           Constants.References.TURN_LEFT,
+                           Constants.References.TURN_RIGHT];
 
   this.addStep(
     new Lesson.LessonStep(
@@ -430,6 +437,7 @@ function Lesson02() {
           Para isso, use o comando "L" (de left, que é esquerda em inglês).
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 5, 3, new Grid.Position(4, 1), Grid.Directions.UP,
         [new Grid.Position(1, 1), new Grid.Position(1, 0)],
@@ -450,6 +458,7 @@ function Lesson02() {
           Mas tenho certeza de que você já pode ajudá-lo.
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 5, 3, new Grid.Position(4, 1), Grid.Directions.LEFT,
         [new Grid.Position(3, 1), new Grid.Position(2, 1),
@@ -475,6 +484,7 @@ function Lesson02() {
           Você consegue pegar as duas baterias verdes sem passar pela estragada?
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 4, 3, new Grid.Position(3, 1), Grid.Directions.UP,
         [new Grid.Position(2, 1), new Grid.Position(0, 1)],
@@ -501,6 +511,7 @@ function Lesson02() {
           Lembre-se de não tocar as baterias vermelhas.
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 6, 10, new Grid.Position(0, 0), Grid.Directions.DOWN,
         [new Grid.Position(0, 7), new Grid.Position(0, 8),
@@ -540,6 +551,7 @@ function Lesson02() {
           que é a mesma coisa. O robô não se importa, e fica mais fácil de entender.
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 6, 10, new Grid.Position(0, 0), Grid.Directions.DOWN,
         [new Grid.Position(0, 7), new Grid.Position(0, 8),
@@ -570,6 +582,7 @@ function Lesson02() {
           Vamos lá, eu já comecei para você.
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 6, 10, new Grid.Position(5, 0), Grid.Directions.DOWN,
         [new Grid.Position(0, 7),
@@ -618,6 +631,7 @@ function Lesson02() {
           e usar laços.
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 6, 6, new Grid.Position(0, 0), Grid.Directions.RIGHT,
         [new Grid.Position(0, 5), new Grid.Position(5, 5)],
@@ -653,6 +667,7 @@ function Lesson02() {
           ou melhor, sem bateria.
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 5, 5, new Grid.Position(0, 0), Grid.Directions.RIGHT,
         [new Grid.Position(0, 4), new Grid.Position(4, 4)],
@@ -678,6 +693,7 @@ function Lesson02() {
           Você consegue ver como fazer o trajeto usando só 8 caracteres?
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 5, 5, new Grid.Position(0, 0), Grid.Directions.RIGHT,
         [new Grid.Position(0, 4), new Grid.Position(4, 4),
@@ -705,6 +721,7 @@ function Lesson02() {
           uma escada? Sei que você consegue!
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 6, 7, new Grid.Position(5, 0), Grid.Directions.UP,
         [new Grid.Position(4, 0), new Grid.Position(3, 1),
@@ -734,6 +751,7 @@ function Lesson02() {
           Escolha bem a ordem em que você vai pegá-las.
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 6, 5, new Grid.Position(5, 0), Grid.Directions.RIGHT,
         [new Grid.Position(4, 0), new Grid.Position(2, 0),
@@ -766,6 +784,7 @@ function Lesson02() {
           já que você já é profissional agora :)
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 6, 6, new Grid.Position(5, 0), Grid.Directions.UP,
         [new Grid.Position(2, 0), new Grid.Position(1, 0),
@@ -796,6 +815,7 @@ function Lesson02() {
           uma ordem diferente. Acredito que você vai conseguir. Vamos lá!
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 6, 7, new Grid.Position(5, 0), Grid.Directions.UP,
         [
@@ -840,6 +860,7 @@ function Lesson02() {
           com pouco código. Experimente você mesmo!
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 10, 10, new Grid.Position(0, 0), Grid.Directions.RIGHT,
         [
@@ -880,6 +901,7 @@ function Lesson02() {
           Você pode fazer isso com laços aninhados :)
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 10, 10, new Grid.Position(9, 9), Grid.Directions.UP,
         [
@@ -933,6 +955,7 @@ function Lesson02() {
           Não se preocupe: na hora certa você vai descobrir.
         </p>
       </div>,
+      commandsReference,
       new Lesson02ExerciseStepPlayer(
         false, 10, 10, new Grid.Position(9, 9), Grid.Directions.UP,
         [

--- a/src/lesson/lesson03.js
+++ b/src/lesson/lesson03.js
@@ -551,6 +551,19 @@ Lesson03ExerciseStepPlayer.prototype = {
 function Lesson03() {
   Lesson.Lesson.call(this);
 
+  var commandsReference = <div>
+                            <div> <b> Comandos </b> </div>
+                            <div> <b>F</b>: se mover para o frente </div>
+                            <div> <b>L</b>: rotar o robô para a esquerda </div>
+                            <div> <b>R</b>: rotar o robô para a direita  </div>
+                            <div> <b>P</b>: pegar engranagem </div>
+                            <div> <b>G</b>: colocar engranagem em máquina </div>
+                            <div> <b>eng?{ }</b>: fazer o que está entre chaves </div>
+                            <div> só se tem uma engranagem na frente </div>
+                            <div> <b>maq?{ }</b>: fazer o que está entre chaves </div>
+                            <div>  só se tem uma máquina na frente </div>
+                          </div>;
+
   // Step 1
   this.addStep(
     new Lesson.LessonStep(
@@ -582,6 +595,7 @@ function Lesson03() {
           significa <b>pegar</b>) para o robô pegar a engrenagem.
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         3, // rows
         3, // cols
@@ -620,6 +634,7 @@ function Lesson03() {
           direita o comando “<b>R</b>” (do inglês, <i>Right</i>).
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         3, // rows
         3, // cols
@@ -653,6 +668,7 @@ function Lesson03() {
           “<b>G</b>” (<i>Get</i>), e para colocar é “<b>P</b>” (<i>Put</i>).
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         3, // rows
         3, // cols
@@ -689,6 +705,7 @@ function Lesson03() {
           você vai precisar utilizar um laço agora.
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         3, // rows
         10, // cols
@@ -721,6 +738,7 @@ function Lesson03() {
           máquina.
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         4, // rows
         3, // cols
@@ -758,6 +776,7 @@ function Lesson03() {
           Vamos tentar?
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         4, // rows
         10, // cols
@@ -806,6 +825,7 @@ function Lesson03() {
           ser útil agora.
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         10, // rows
         10, // cols
@@ -849,6 +869,7 @@ function Lesson03() {
           de repetição aqui também.
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         9, // rows
         9, // cols
@@ -920,6 +941,7 @@ function Lesson03() {
           Senão o comando “G” não vai ser executado.
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         3, // rows
         3, // cols
@@ -970,6 +992,7 @@ function Lesson03() {
           Então vamos lá, vai ser fácil.
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         3, // rows
         3, // cols
@@ -1008,6 +1031,7 @@ function Lesson03() {
           todos eles!
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         3, // rows
         10, // cols
@@ -1057,6 +1081,7 @@ function Lesson03() {
           Acho que usando um laço vai ficar fácil.
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         3, // rows
         10, // cols
@@ -1098,6 +1123,7 @@ function Lesson03() {
           com a sala anterior? Pense um pouco e resolva.
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         3, // rows
         10, // cols
@@ -1140,6 +1166,7 @@ function Lesson03() {
           nessa sala também.
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         6, // rows
         10, // cols
@@ -1192,6 +1219,7 @@ function Lesson03() {
           frente a uma máquina.
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         3, // rows
         5, // cols
@@ -1228,6 +1256,7 @@ function Lesson03() {
           como fazer para consertar todas as máquinas dessa sala?
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         2, // rows
         10, // cols
@@ -1265,6 +1294,7 @@ function Lesson03() {
           programa vai fazer o robô resolver o problema nessa sala?
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         2, // rows
         10, // cols
@@ -1299,6 +1329,7 @@ function Lesson03() {
           e logo logo toda a nossa base estará funcionando!
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         3, // rows
         10, // cols
@@ -1333,6 +1364,7 @@ function Lesson03() {
           Um novo desafio, mas tenho certeza que você consegue resolvê-lo!
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         3, // rows
         10, // cols
@@ -1370,6 +1402,7 @@ function Lesson03() {
           chaves do condicional, inclusive laços!
         </p>
       </div>,
+      commandsReference,
       new Lesson03ExerciseStepPlayer(
         8, // rows
         10, // cols

--- a/src/lesson/lesson03.js
+++ b/src/lesson/lesson03.js
@@ -551,18 +551,10 @@ Lesson03ExerciseStepPlayer.prototype = {
 function Lesson03() {
   Lesson.Lesson.call(this);
 
-  var commandsReference = <div>
-                            <div> <b> Comandos </b> </div>
-                            <div> <b>F</b>: se mover para o frente </div>
-                            <div> <b>L</b>: rotar o robô para a esquerda </div>
-                            <div> <b>R</b>: rotar o robô para a direita  </div>
-                            <div> <b>P</b>: pegar engranagem </div>
-                            <div> <b>G</b>: colocar engranagem em máquina </div>
-                            <div> <b>eng?{ }</b>: fazer o que está entre chaves </div>
-                            <div> só se tem uma engranagem na frente </div>
-                            <div> <b>maq?{ }</b>: fazer o que está entre chaves </div>
-                            <div>  só se tem uma máquina na frente </div>
-                          </div>;
+  var commandsReference = [Constants.References.MOVE_FORWARD,
+                           Constants.References.TURN_LEFT,
+                           Constants.References.TURN_RIGHT,
+                           Constants.References.GET_COMPONENT];
 
   // Step 1
   this.addStep(
@@ -612,6 +604,9 @@ function Lesson03() {
       null
     )
   );
+
+  commandsReference = [commandsReference,
+                       Constants.References.PUT_COMPONENT];
 
   // Step 2
   this.addStep(
@@ -905,6 +900,9 @@ function Lesson03() {
     )
   );
 
+  commandsReference = [commandsReference,
+                       Constants.References.COMPONENT_SENSOR];
+
   // Step 9
   this.addStep(
     new Lesson.LessonStep(
@@ -1195,6 +1193,9 @@ function Lesson03() {
       null
     )
   );
+
+  commandsReference = [commandsReference,
+                       Constants.References.MACHINE_SENSOR];
 
   // Step 15
   this.addStep(

--- a/src/view/command_reference_sidebar.js
+++ b/src/view/command_reference_sidebar.js
@@ -1,0 +1,62 @@
+/*
+ * Component that shows a sidebar explaining the commands used in 
+ * a lesson step
+ */
+
+var React = require("react");
+var Constants = require("../constants");
+var ResourceLoader = require("../util/resource_loader");
+var Sidebar = require('react-sidebar').default;
+
+var CommandReferenceSidebar = React.createClass({
+  styles: {
+    root: {
+      fontWeight: 300,
+    },
+    header: {
+      backgroundColor: '#03a9f4',
+      color: 'white',
+      padding: '16px',
+      fontSize: '1.5em',
+    },
+    content: {
+      marginLeft: '16px',
+      marginRight: '16px',
+      height: '100%',
+      backgroundColor: 'white',
+      marginBottom: "4%",
+    },
+    link: {
+      textDecoration: 'none',
+      color: 'white',
+      padding: '8px',
+    },
+  },
+
+  render: function() {
+    var commandReference = [];
+    for (var i = 0; i < this.props.content.length; i++) {
+      commandReference.push(this.props.content[i]);
+    }
+      
+    return <div style={{width: "100%", height: "100%"}}>
+              <div style={this.styles.root}>
+                <div style={this.styles.header}> 
+                  <span> Comandos </span> 
+                  <span style={{float: "right"}}>
+                    <a href='#'
+                       onClick={this.props.onClose}
+                       style={this.styles.link}> 
+                      X 
+                    </a>
+                  </span>
+                </div>
+                <div style={this.styles.content}>
+                  {commandReference}
+                </div>
+              </div>
+           </div>;
+  },
+});
+
+module.exports = CommandReferenceSidebar;

--- a/src/view/lesson_environment.js
+++ b/src/view/lesson_environment.js
@@ -11,19 +11,20 @@ var MessagePane = require("./message_pane.js");
 var ResourceLoader = require("../util/resource_loader");
 var Popup = require("react-popup").default;
 var Sidebar = require('react-sidebar').default;
+var CommandReferenceSidebar = require('./command_reference_sidebar.js');
 
 var LessonEnvironment = React.createClass({
   styles: {
     instructionPane: {
-      width: "100%",
+      width: "95%",
       height: "20%",
       margin: "0",
     },
     actionSide: {
       width: "70%",
       height: "100%",
-      float: "right",
-      margin: "0",
+      float: "left",
+      marginLeft: "20px",
     },
     editor: {
       float: "left",
@@ -32,7 +33,7 @@ var LessonEnvironment = React.createClass({
       margin: "0px",
     },
     buttonBar: {
-      width: "100%",
+      width: "95%",
       height: "5%",
       margin: "0",
     },
@@ -47,6 +48,7 @@ var LessonEnvironment = React.createClass({
     return {
       sourceCode: "",
       currentStep: 0,
+      docked: true,
     };
   },
 
@@ -131,11 +133,44 @@ var LessonEnvironment = React.createClass({
     this._startStep(0);
   },
 
+  _closeSidebar: function() {
+    this.setState({docked: false});
+  },
+  
+  _openSidebar: function() {
+    this.setState({docked: true});
+  },
+
+  showButton: function() {
+    if (!this.state.docked) {      
+      return <div style={{width: "20px",
+                          float: "right",
+                          backgroundColor: '#03a9f4'}}>
+               <a href='#'
+                  onClick={this._openSidebar}
+                  style={{textDecoration: 'none', color: 'white'}}> 
+                 C
+                 O
+                 M
+                 A
+                 N
+                 D
+                 O
+                 S
+               </a>
+             </div>;
+    }
+    return <div> </div>;
+  },
+
   render: function() {
     var currentStep = this.props.lesson.getStep(this.state.currentStep);
 
-    return <Sidebar sidebar={currentStep.getCommandReference()}
-                    docked={true}
+    var commandReferenceSidebar = <CommandReferenceSidebar onClose={this._closeSidebar} 
+                                                             content={currentStep.getCommandReference()} />;
+
+    return <Sidebar sidebar={commandReferenceSidebar}
+                    docked={this.state.docked}
                     pullRight={true}>
              <div style={{width: "100%", height: "95%"}} ref="containerDiv">
                <div style={this.styles.editor}>
@@ -160,6 +195,7 @@ var LessonEnvironment = React.createClass({
                    <RunView ref="run_view" />
                  </div>
                </div>
+               {this.showButton()}
              </div>
            </Sidebar>;
   },

--- a/src/view/lesson_environment.js
+++ b/src/view/lesson_environment.js
@@ -10,6 +10,7 @@ var RunView = require("./run_view.js");
 var MessagePane = require("./message_pane.js");
 var ResourceLoader = require("../util/resource_loader");
 var Popup = require("react-popup").default;
+var Sidebar = require('react-sidebar').default;
 
 var LessonEnvironment = React.createClass({
   styles: {
@@ -133,30 +134,34 @@ var LessonEnvironment = React.createClass({
   render: function() {
     var currentStep = this.props.lesson.getStep(this.state.currentStep);
 
-    return <div style={{width: "100%", height: "100%"}} ref="containerDiv">
-             <div style={this.styles.editor}>
-               <MessagePane ref="code_messages" />
-               <CodeEditor code={this.state.sourceCode}
-                           onChange={this._updateCode}
-                           limit={currentStep.getCodeSizeLimit()} />
+    return <Sidebar sidebar={currentStep.getCommandReference()}
+                    docked={true}
+                    pullRight={true}>
+             <div style={{width: "100%", height: "95%"}} ref="containerDiv">
+               <div style={this.styles.editor}>
+                 <MessagePane ref="code_messages" />
+                 <CodeEditor code={this.state.sourceCode}
+                             onChange={this._updateCode}
+                             limit={currentStep.getCodeSizeLimit()} />
+               </div>
+               <div style={this.styles.actionSide}>
+                 <div style={this.styles.instructionPane}>
+                   <MessagePane ref="exercise_messages" />
+                   <InstructionPane content={currentStep.getShortInstructions()} />
+                 </div>
+                 <div style={this.styles.buttonBar}>
+                   <ButtonBar onPlay={this._playCode}
+                              onReset={this._reset}
+                              onAdvance={this._advanceStep}
+                              onHelp={this._showInstructions.bind(this, null)}
+                              advanceEnabled={currentStep.canAdvance()} />
+                 </div>
+                 <div style={this.styles.runView}>
+                   <RunView ref="run_view" />
+                 </div>
+               </div>
              </div>
-             <div style={this.styles.actionSide}>
-               <div style={this.styles.instructionPane}>
-                 <MessagePane ref="exercise_messages" />
-                 <InstructionPane content={currentStep.getShortInstructions()} />
-               </div>
-               <div style={this.styles.buttonBar}>
-                 <ButtonBar onPlay={this._playCode}
-                            onReset={this._reset}
-                            onAdvance={this._advanceStep}
-                            onHelp={this._showInstructions.bind(this, null)}
-                            advanceEnabled={currentStep.canAdvance()} />
-               </div>
-               <div style={this.styles.runView}>
-                 <RunView ref="run_view" />
-               </div>
-             </div>
-           </div>;
+           </Sidebar>;
   },
 
   componentDidMount: function() {


### PR DESCRIPTION
Added a panel to the right of the screen. Initially, it appears open, and it can be closed and reopened as the user wishes. During a step it will not close/open unless the user clicks on the open/close button. Between steps the state of the panel remains the same (if it was open, it will not close and the converse is also true).

Attaching screenshots of the two states (first, open; second, closed).
![14599706_10209765140501507_1962660974_o png](https://cloud.githubusercontent.com/assets/8364317/19202267/dcbe7546-8ca7-11e6-887f-8f714e9e9100.jpeg)
![14572620_10209765140541508_852531104_o png](https://cloud.githubusercontent.com/assets/8364317/19202266/dcb90714-8ca7-11e6-8d34-4c8db75a0197.jpeg)

