### PR TITLE
Add option to minify bundle.js during build.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,4 +22,10 @@ npm install .
 echo "Building file bundle.js..."
 jsx src/ build/
 browserify build/app.js --s comp4kids > bundle.js
+
+if [[ $1 == "--release" ]]
+then
+  node minify_bundle.js
+fi
+
 browserify build/test/test_app.js --s comp4kids > test_bundle.js

--- a/minify_bundle.js
+++ b/minify_bundle.js
@@ -1,0 +1,22 @@
+/*
+ * Minifies the bundle.js file produced during build.
+ */
+
+var Packer = require("node.packer");
+
+console.log("Minifying bundle.js...");
+
+Packer({
+  log : true,
+  input : ["bundle.js"],
+  output : "bundle-min.js",
+  minify: true,
+  callback: function (err) {
+    if (err) {
+      console.log(err);
+    } else {
+      console.log("Done!");
+    }
+  }
+});
+

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react-dom": "15.0.2",
     "react-popup": "0.4.2",
     "react-sidebar": "2.2.1",
-    "codeeditor": "1.0.4"
+    "codeeditor": "1.0.4",
+    "node.packer": "2.0.3"
   }
 }


### PR DESCRIPTION
Add a --release option to minify the generated bundle.js
in a file called 'bundle-min.js'. This file is still not used anywhere;
however, we may use it in the 'real' client of the app (i.e. not in
tests/lessons/..., which we can keep for development/debugging).

This reduces the size of the file from
1.5M (328K gzipped) to
884K (192K gzipped).