### PR TITLE
Fix broken message when loop trip size exceeds its limit

### DIFF
--- a/src/language/robolang/analysis.js
+++ b/src/language/robolang/analysis.js
@@ -32,14 +32,19 @@ function countNodeTypes(program) {
 
 function getMaxLoopTripCount(program) {
   var maxLoop = 0;
+  var location = null;
   traverseAST(program.getASTRoot(),
               function(node) {
                 if (node.type.name == Parser.ASTNodeTypes.LOOP.name) {
                   maxLoop = Math.max(maxLoop, node.attributes.tripCount);
+                  location = node.location;
                 }
               });
 
-  return maxLoop;
+  return {
+      maxLoop: maxLoop,
+      location: location
+  };
 }
 
 module.exports = {

--- a/src/language/robolang/test/test_analysis.js
+++ b/src/language/robolang/test/test_analysis.js
@@ -25,12 +25,12 @@ function testMaxLoopTripCount() {
   var program = Robolang.CompileRobolangProgram("15{X 10{Y}} 19{Z}",
                                                 ["X", "Y", "Z"]);
     assert.equal(true, program instanceof Robolang.RobolangProgram);
-  assert.equal(19, Analysis.getMaxLoopTripCount(program));
+  assert.equal(19, Analysis.getMaxLoopTripCount(program).maxLoop);
 
   program = Robolang.CompileRobolangProgram("10{X 15{Y}} 20{Z}",
                                             ["X", "Y", "Z"]);
   assert.equal(true, program instanceof Robolang.RobolangProgram);
-  assert.equal(20, Analysis.getMaxLoopTripCount(program));
+  assert.equal(20, Analysis.getMaxLoopTripCount(program).maxLoop);
 }
 
 module.exports = {


### PR DESCRIPTION
SemanticAnalysisErrors were presented in an unsupported manner, leading to no message being displayed in case of loop trips exceeding their size limit.
Before:
![screenshot 2017-05-17 at 6 01 03 pm](https://cloud.githubusercontent.com/assets/6827321/26175984/f56e40bc-3b2a-11e7-9f24-1ebbb041d2d9.png)

After:
![screenshot 2017-05-17 at 6 01 58 pm](https://cloud.githubusercontent.com/assets/6827321/26175998/0087cb80-3b2b-11e7-811f-9f3ee3986597.png)

